### PR TITLE
Add configuration for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: perl
+
+perl:
+    - "5.18"
+    - "5.14"
+    - "5.10"
+
+notifications:
+  irc:
+    channels:
+      - "irc.perl.org#dancer"
+    template:
+      - "%{branch}#%{build_number} by %{author}: %{message} (%{build_url})"
+    on_success: change
+    on_failure: always
+    use_notice: true
+
+install:
+    - cpanm .
+
+script:
+    - make test

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,15 @@ my %WriteMakefileArgs = (
   'VERSION' => '0.1.1',
   'test' => {
     'TESTS' => 't/*.t'
-  }
+  },
+  'META_MERGE' {
+      resources => {
+          homepage    => 'https://github.com/VeroLom/Dancer2-Template-MojoTemplate',
+          license     => 'http://www.opensource.org/licenses/artistic-license-2.0',
+          repository  => 'https://github.com/VeroLom/Dancer2-Template-MojoTemplate',
+          bugtracker  => 'https://github.com/VeroLom/Dancer2-Template-MojoTemplate/issues'
+      },
+  },
 );
 
 


### PR DESCRIPTION
Hey Nikita,

I would like to add a configuration to travis for this project. I'm trying to maintain a list of all the plugin and extensions for Dancer2, and I would like to monitor their status. By using Travis we can get an idea of the state of things (is Dancer2 breaking stuff, or is an API changed, etc). If you need details on how to setup the travis hook for this project, please let me know and I'll help. If a build fail a notification will be send on irc (#dancer) so people will now (and maybe help to fix the issue).

Also, I've updated the Makefile.PL to add a "resources" section, so people going to metacpan can get the URL to the repository.

Thanks!
